### PR TITLE
Handle out-of-range indices in set_false_at_index

### DIFF
--- a/jaxcmr/analyses/crp.py
+++ b/jaxcmr/analyses/crp.py
@@ -153,9 +153,19 @@ def simple_crp(
 
 
 def set_false_at_index(vec: Bool[Array, " positions"], i: Int_):
-    """Set ``vec[i - 1]`` to ``False`` when ``i`` is non-zero."""
+    """Set ``vec[i - 1]`` to ``False`` using 1-based indexing.
 
-    return lax.cond(i, lambda: (vec.at[i - 1].set(False), None), lambda: (vec, None))
+    Indices are 1-based; ``0`` is a no-op sentinel. Indices outside
+    ``[1, vec.size]`` are ignored.
+
+    Returns:
+        Tuple of the (possibly updated) vector and ``None``.
+    """
+
+    should_update = (i > 0) & (i <= vec.size)
+    return lax.cond(
+        should_update, lambda: (vec.at[i - 1].set(False), None), lambda: (vec, None)
+    )
 
 
 class Tabulation(Pytree):

--- a/tests/test_crp.py
+++ b/tests/test_crp.py
@@ -86,6 +86,32 @@ def test_returns_tuple_and_none_when_updating_index():
     assert updated.tolist() == [True, False]
 
 
+def test_set_false_at_index_out_of_range_is_noop():
+    """Behavior: Out-of-range indices leave vector unchanged.
+
+    Given:
+      - A boolean vector.
+    When:
+      - ``set_false_at_index`` is called with negative or too-large index.
+    Then:
+      - The vector is unchanged and ``None`` is returned.
+    Why this matters:
+      - Prevents unintended updates for invalid positions.
+    """
+    # Arrange / Given
+    vec = jnp.array([True, True], dtype=bool)
+
+    # Act / When
+    updated_large, flag_large = crp.set_false_at_index(vec, 99)
+    updated_neg, flag_neg = crp.set_false_at_index(vec, -5)
+
+    # Assert / Then
+    assert updated_large.tolist() == vec.tolist()
+    assert updated_neg.tolist() == vec.tolist()
+    assert flag_large is None
+    assert flag_neg is None
+
+
 # -----------------------------------------------------------------------------
 # Tabulation: sentinel and validity tests
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clarify 1-based indexing and sentinel behavior for `set_false_at_index`
- Safely ignore zero or out-of-range indices when clearing availability
- Test that invalid indices leave vectors unchanged

## Testing
- `ruff check jaxcmr/analyses/crp.py tests/test_crp.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jax'; attempted `pip install jax jaxlib` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5108117788332b32daf5b6f37336f