### PR TITLE
Use non-interactive matplotlib backend in CRP tests

### DIFF
--- a/tests/test_crp.py
+++ b/tests/test_crp.py
@@ -1,6 +1,8 @@
+import matplotlib
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
 import jax
 import jax.numpy as jnp
-import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 import pytest


### PR DESCRIPTION
## Summary
- Configure `matplotlib` to use the non-interactive Agg backend in CRP tests

## Testing
- `ruff check tests/test_crp.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_68c510b7bdb883328ab779f14cf64b44