### PR TITLE
Use jnp.array_equal in set_false_at_index tests

### DIFF
--- a/tests/test_crp.py
+++ b/tests/test_crp.py
@@ -59,7 +59,7 @@ def test_flips_element_to_false_when_idx_positive(vec, idx, expected):
     updated, _ = crp.set_false_at_index(vec, idx)
 
     # Assert / Then
-    assert updated.tolist() == expected
+    assert jnp.array_equal(updated, jnp.array(expected, dtype=bool)).item()
 
 
 def test_returns_tuple_and_none_when_updating_index():
@@ -83,7 +83,7 @@ def test_returns_tuple_and_none_when_updating_index():
     # Assert / Then
     assert isinstance(updated, jnp.ndarray)
     assert flag is None
-    assert updated.tolist() == [True, False]
+    assert jnp.array_equal(updated, jnp.array([True, False], dtype=bool)).item()
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ensure boolean arrays in `set_false_at_index` tests are compared with `jnp.array_equal` for type-safe equality checks

## Testing
- `ruff check tests/test_crp.py`
- `pytest tests/test_crp.py::test_flips_element_to_false_when_idx_positive` *(fails: ModuleNotFoundError: No module named 'jax')*


------
https://chatgpt.com/codex/tasks/task_e_68c510bcb99883329377e0d3d17f6e6a